### PR TITLE
Hide "save to tiddlyhost" button if user is not logged in for Classic

### DIFF
--- a/rails/lib/th_file.rb
+++ b/rails/lib/th_file.rb
@@ -139,6 +139,7 @@ class ThFile < TwFile
       },
 
       # Used in the ThostUploadPlugin to ensure we don't render in readonly mode
+      # and to show the 'save to tiddlyhost' button
       'TiddlyHostIsLoggedIn' => {
         text: status_is_logged_in(is_logged_in:, for_download:),
         modifier: 'TiddlyHost',

--- a/rails/tw_content/plugins/thost_upload_plugin.js.erb
+++ b/rails/tw_content/plugins/thost_upload_plugin.js.erb
@@ -192,10 +192,15 @@ bidix.initOption('txtThostSiteName','<%= site_name %>');
 // Tiddlyhost stuff
 //
 
-// So you can see edit controls via http
-config.options.chkHttpReadOnly = false;
-window.readOnly = false;
-window.showBackstage = true;
+if (config.shadowTiddlers.TiddlyHostIsLoggedIn == "yes") {
+  // If user is logged in to Tiddlyhost and viewing their own site then
+  // we disregard the original value of the chkHttpReadOnly cookie
+  config.options.chkHttpReadOnly = false
+  // window.readOnly gets set before plugins are loaded, so we need to
+  // set it here to make sure TW is editable, unlike window.showBackstage
+  // which is set after
+  window.readOnly = false
+}
 
 // Add 'upload to tiddlyhost' button
 config.shadowTiddlers.SideBarOptions = config.shadowTiddlers.SideBarOptions

--- a/rails/tw_content/plugins/thost_upload_plugin.js.erb
+++ b/rails/tw_content/plugins/thost_upload_plugin.js.erb
@@ -200,10 +200,10 @@ if (config.shadowTiddlers.TiddlyHostIsLoggedIn == "yes") {
   // set it here to make sure TW is editable, unlike window.showBackstage
   // which is set after
   window.readOnly = false
-}
 
-// Add 'upload to tiddlyhost' button
-config.shadowTiddlers.SideBarOptions = config.shadowTiddlers.SideBarOptions
-  .replace(/(<<saveChanges>>)/,"$1<<thostUpload>>");
+  // Add the 'save to tiddlyhost' button after the regular save button
+  config.shadowTiddlers.SideBarOptions = config.shadowTiddlers.SideBarOptions
+    .replace(/(<<saveChanges>>)/,"$1<<thostUpload>>");
+}
 
 //}}}


### PR DESCRIPTION
Inject a shadow tiddler with content set to either 'yes' or 'no', then look for that shadow tiddler in the upload plugin.

WIP, but it's generally working.

This is for #326 fyi @YakovL .