### PR TITLE
Inject tiddlers for social media preview metadata

### DIFF
--- a/rails/lib/settings.rb
+++ b/rails/lib/settings.rb
@@ -82,6 +82,10 @@ class Settings
     ActionDispatch::Http::URL.full_url_for(Settings.url_defaults.merge(subdomain: site_name))
   end
 
+  def self.site_thumbnail_url(site_name)
+    "#{subdomain_site_url(site_name)}/thumb.png"
+  end
+
   def self.tiddlyspot_site_host(site_name)
     "#{site_name}.#{Settings.tiddlyspot_host}"
   end

--- a/rails/lib/th_file.rb
+++ b/rails/lib/th_file.rb
@@ -94,6 +94,15 @@ class ThFile < TwFile
 
       # Provide a way for TiddlyWikis to detect when they're able to be saved
       '$:/status/IsLoggedIn' => status_is_logged_in(is_logged_in:, for_download:),
+
+      # Used in `$:/core/templates/social-metadata` for social media preview metadata.
+      # (It seems like it would be unexpected for these to be set in a downloaded file,
+      # so set them to an empty string if we're preparing for a download.)
+      # Todo maybe: Allow the user to customize the preview image url, perhaps by creating
+      # it as a shadow tiddler
+      '$:/SiteUrl' => (for_download ? '' : Settings.subdomain_site_url(site_name)),
+      '$:/SiteDomain' => (for_download ? '' : Settings.subdomain_site_host(site_name)),
+      '$:/SitePreviewImageUrl' => (for_download ? '' : Settings.site_thumbnail_url(site_name)),
     })
 
     # Since every save uploads the entire TiddlyWiki I want to discourage

--- a/rails/lib/tw_file.rb
+++ b/rails/lib/tw_file.rb
@@ -167,6 +167,8 @@ class TwFile
   def write_tiddlers(tiddlers, shadow: false)
     if json_store?
       # Assume we're using TW 5.2 and later
+      # Note that we don't support shadow tidders for the json store,
+      # see https://github.com/simonbaird/tiddlyhost/issues/341
       append_json_store(tiddlers)
 
     else


### PR DESCRIPTION
An upcoming release of TiddlyWiki will include a
`$:/core/templates/social-metadata` tiddler that will produce metadata used by social media link previews.

See https://github.com/TiddlyWiki/TiddlyWiki5/pull/8441

Provide some tiddler content to make that work for TW5 sites on Tiddlyhost.
